### PR TITLE
[BUG] `make setup` doesn't work

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,10 +11,11 @@ System Requirements
 .. note::
 
     Due to the way that ``tox`` works with environment setup, if your system's
-    Python 3 version is 3.6.x and you install `pgcli <https://www.pgcli.com/>`_,
-    ``make setup`` will fail. This is due to a `known bug <https://github.com/OCA/pylint-odoo/issues/144>`_
-    in ``pbr`` and as of 2017-12-01 there is no workaround that doesn't break
-    ``pgcli``. You'll need to uninstall it.
+    Python 3 version is 3.6.x and you installed any Python package that uses
+    ``cli-helpers`` version 0.2.0 or greater, ``make setup`` will fail. This is
+    due to a `known bug <https://github.com/OCA/pylint-odoo/issues/144>`_ in
+    ``pbr`` and as of 2017-12-02 there is no workaround that won't potentially
+    break other packages.
 
 Setup
 -----

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,13 +6,19 @@ System Requirements
 
 * PostgreSQL 9.1 or greater must be installed.
 * Python 3.3 or greater. Compatibility with PyPy3.5 is untested and not guaranteed.
-* A database driver supported by SQLAlchemy must also be installed (see full list
-  `here <http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#dialect-postgresql>`_).
-  `psycopg2 <http://initd.org/psycopg/>`_ is guaranteed to work;
-  `pg8000 <https://github.com/mfenniak/pg8000/>`_ on the other hand is known to
-  be incompatible with pytest-pgsql.
+* You must use ``psycopg2`` as your database driver.
+
+.. note::
+
+    Due to the way that ``tox`` works with environment setup, if your system's
+    Python 3 version is 3.6.x and you install `pgcli <https://www.pgcli.com/>`_,
+    ``make setup`` will fail. This is due to a `known bug <https://github.com/OCA/pylint-odoo/issues/144>`_
+    in ``pbr`` and as of 2017-12-01 there is no workaround that doesn't break
+    ``pgcli``. You'll need to uninstall it.
 
 Setup
 -----
 
-pip3 install pytest-pgsql
+.. code-block:: sh
+
+    pip3 install pytest-pgsql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-freezegun>=0.3.6,<0.4.0
-pytest>=3.0.0,<4.0.0; python_version>="3.4"
-pytest>=3.0.0,<3.3.0; python_version<"3.4"
-sqlalchemy>=1.1.0,<1.2.0
-testing.postgresql>=1.3.0,<2.0.0
+freezegun>=0.3.6
+pytest>=3.0.0; python_version>="3.4"
+pytest>=3.0,<3.3; python_version<"3.4"
+sqlalchemy>=1.1.0
+testing.postgresql>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-freezegun>=0.3.6
-pytest>=3.0.0; python_version>="3.4"
-pytest>=3.0,<3.3; python_version<"3.4"
-sqlalchemy>=1.1.0
-testing.postgresql>=1.3.0
+freezegun>=0.3.6,<0.4.0
+pytest>=3.0.0,<4.0.0; python_version>="3.4"
+pytest>=3.0.0,<3.3.0; python_version<"3.4"
+sqlalchemy>=1.1.0,<1.2.0
+testing.postgresql>=1.3.0,<2.0.0


### PR DESCRIPTION
`make setup` doesn't work if you try to run the tests afterwards. This is because only one version of Python is installed. You need all supported versions.

To reproduce:

1. Clone the repo
2. Run `make setup`
3. Run `tox`

If `make setup` doesn't crash (see incompatibility notice) then you'll see a bunch of tox setup errors and then this at the end of the test run:

```
ERROR:   py33: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError('Failed to get version_info for python3.3: b"pyenv: python3.3: command not found\\n\\nThe `python3.3\' command exists in these Python versions:\\n  3.3.6\\n\\n"',)
ERROR:   py34: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError('Failed to get version_info for python3.4: b"pyenv: python3.4: command not found\\n\\nThe `python3.4\' command exists in these Python versions:\\n  3.4.7\\n\\n"',)
ERROR:   py35: Error creating virtualenv. Note that some special characters (e.g. ':' and unicode symbols) in paths are not supported by virtualenv. Error details: InvocationError('Failed to get version_info for python3.5: b"pyenv: python3.5: command not found\\n\\nThe `python3.5\' command exists in these Python versions:\\n  3.5.4\\n\\n"',)
ERROR:   py36: commands failed
```