### PR TITLE
[BUG] Remove silently ignored --pg-driver CLI option.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -315,20 +315,6 @@ Now, in our tests we can use the fixtures directly::
 Command Line Options
 --------------------
 
-``--pg-driver``
-~~~~~~~~~~~~~~~
-
-Use this to tell the fixtures which database driver to use. The default if not
-given is `psycopg2 <http://initd.org/psycopg/>`_. SQLAlchemy supports all the
-drivers listed `here <http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#dialect-postgresql>`_
-but some may not work with ``pytest_pgsql``. [#]_
-
-Usage:
-
-.. code-block:: sh
-
-    pytest --pg-driver pygresql
-
 ``--pg-extensions``
 ~~~~~~~~~~~~~~~~~~~
 

--- a/pytest_pgsql/database.py
+++ b/pytest_pgsql/database.py
@@ -632,10 +632,8 @@ class PostgreSQLTestDBBase(metaclass=abc.ABCMeta):
             else:
                 quoted_table = quote(schema_name)
 
-            cascade_clause = 'CASCADE' if cascade else ''
-
             self._conn.execute('TRUNCATE TABLE ONLY %s RESTART IDENTITY %s'
-                               % (quoted_table, cascade_clause))
+                               % (quoted_table, 'CASCADE' if cascade else ''))
 
         if isinstance(csv_source, str):
             with open(csv_source, 'r') as fdesc:

--- a/pytest_pgsql/plugin.py
+++ b/pytest_pgsql/plugin.py
@@ -30,8 +30,8 @@ def database_uri(request):
 
     work_mem = request.config.getoption('--pg-work-mem')
     if work_mem < 0:    # pragma: no cover
-        return pytest.exit('ERROR: --pg-work-mem value must be >= 0. Got: %d'
-                           % work_mem)
+        pytest.exit('ERROR: --pg-work-mem value must be >= 0. Got: %d' % work_mem)
+        return
     elif work_mem == 0:  # pragma: no cover
         # Disable memory tweak and use the server default.
         work_mem_setting = ''

--- a/pytest_pgsql/plugin.py
+++ b/pytest_pgsql/plugin.py
@@ -1,7 +1,5 @@
 """This forms the core of the pytest plugin."""
 
-import sys
-
 import pytest
 import testing.postgresql
 

--- a/pytest_pgsql/tests/database_test.py
+++ b/pytest_pgsql/tests/database_test.py
@@ -6,9 +6,6 @@ import io
 import random
 import tempfile
 
-import pytest_pgsql.time
-from pytest_pgsql import errors
-
 import pytest
 import sqlalchemy as sqla
 import sqlalchemy.engine as sqla_eng
@@ -16,6 +13,9 @@ import sqlalchemy.exc as sqla_exc
 import sqlalchemy.ext.declarative as sqla_decl
 from sqlalchemy import func as sqla_func
 import sqlalchemy.sql as sqla_sql
+
+import pytest_pgsql.time
+from pytest_pgsql import errors
 
 DeclBase = sqla_decl.declarative_base()
 

--- a/pytest_pgsql/tests/time_test.py
+++ b/pytest_pgsql/tests/time_test.py
@@ -2,10 +2,10 @@
 
 import datetime
 
-import pytest_pgsql
 import pytest
 import sqlalchemy.orm as sqla_orm
 
+import pytest_pgsql
 
 _PGFREEZE_DATETIME_TZ = datetime.datetime(2099, 12, 31, 23, 59, 59, 123000,
                                           datetime.timezone.utc)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,7 @@ pytest>=3.0,<3.3; python_version<"3.4"
 coverage==4.4.2
 flake8==3.5.0
 psycopg2==2.7.3
-pylint==1.7.4
+pylint==1.8.1
 pytest-mock==1.6.3
 pytest-profiling==1.2.11
 pytest-randomly==1.2.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,8 @@ pytest>=3.0,<3.3; python_version<"3.4"
 coverage==4.4.2
 flake8==3.5.0
 psycopg2==2.7.3
-pylint==1.8.1
+pylint==1.8.1; python_version>'3.3'
+pylint==1.7.5; python_version=='3.3'
 pytest-mock==1.6.3
 pytest-profiling==1.2.11
 pytest-randomly==1.2.2


### PR DESCRIPTION
Version 1.0.2 removed the ability to specify your Postgres driver but didn't remove the ``--pg-driver`` CLI option. This resulted in a bug where passing ``--pg-driver`` to `pytest` wouldn't change the driver. Since there's no way to work around this, we have to remove the CLI option.

@wesleykendall 