### PR TITLE
Disable pylint false positive.

### DIFF
--- a/pytest_pgsql/database.py
+++ b/pytest_pgsql/database.py
@@ -301,7 +301,9 @@ class PostgreSQLTestDBBase(metaclass=abc.ABCMeta):
         """.format(table_query=TABLE_SNAPSHOT_QUERY))
 
         orig_tables = self.get_table('pytest_pgsql.original_tables')
+        # pylint: disable=no-value-for-parameter
         self._conn.execute(orig_tables.insert().values(self._restore_state['tables']))
+        # pylint: enable=no-value-for-parameter
 
         self._undo_table_renames()
         self._clean_up_schemas()


### PR DESCRIPTION
This PR disables a pylint false positive related to the SQLAlchemy `util.dependencies` decorator, which changes the signature of decorated functions. This is my favorite technique for confusing pylint; it is very effective.