### PR TITLE
Add postgresql.conf options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ test:
 	tox ${TOX_POSARGS}
 	coverage report
 
+test_single_version:
+    coverage run -a -m pytest --pg-conf-opt="track_commit_timestamp=True" --pg-extensions=btree_gin,,btree_gist pytest_pgsql/tests
+
 
 # Run any services for local development. For example, docker databases, CSS compilation watching, etc
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,9 @@ test:
 	tox ${TOX_POSARGS}
 	coverage report
 
+.PHONY: test_single_version
 test_single_version:
-    coverage run -a -m pytest --pg-conf-opt="track_commit_timestamp=True" --pg-extensions=btree_gin,,btree_gist pytest_pgsql/tests
+	coverage run -a -m pytest --pg-conf-opt="track_commit_timestamp=True" --pg-extensions=btree_gin,,btree_gist pytest_pgsql/tests
 
 
 # Run any services for local development. For example, docker databases, CSS compilation watching, etc

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,6 @@ aliases:
       echo ". ~/venv/bin/activate" >> $BASH_ENV
       source $BASH_ENV
       make dependencies
-      pyenv local 3.6.2 3.5.3 3.4.4
 
 
 jobs:
@@ -33,16 +32,12 @@ jobs:
             sudo apt-get update && sudo apt install postgresql postgresql-contrib
       - run:
           <<: *dependencies
-      - run: make test
+      - run: make test_single_version
       - store_test_results:
           path: /tmp/test-reports
       - store_artifacts:
           path: /tmp/test-reports
 
-test:
-  override:
-    - make validate
-    - make test
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -43,5 +43,6 @@ workflows:
   version: 2
   checks_and_deploy:
     jobs:
+      - temple_check
       - lint
       - test

--- a/circle.yml
+++ b/circle.yml
@@ -43,3 +43,10 @@ test:
   override:
     - make validate
     - make test
+
+workflows:
+  version: 2
+  checks_and_deploy:
+    jobs:
+      - lint
+      - test

--- a/circle.yml
+++ b/circle.yml
@@ -43,6 +43,5 @@ workflows:
   version: 2
   checks_and_deploy:
     jobs:
-      - temple_check
       - lint
       - test

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,15 @@ jobs:
       - store_artifacts:
           path: /tmp/test-reports
 
+  deploy:
+    docker:
+      - image: *docker_image
+    steps:
+      - checkout
+      - run:
+          <<: *dependencies
+      - run: pip install -q -r deploy_requirements.txt
+      - run: python3 deploy.py
 
 workflows:
   version: 2
@@ -45,3 +54,11 @@ workflows:
     jobs:
       - lint
       - test
+      - deploy:
+          requires:
+            - lint
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,45 @@
-machine:
-  python:
-    version: 3.6.2
+version: 2
+aliases:
+  - &docker_image circleci/python:3.6.2-stretch
+  - &dependencies
+    name: Make virtualenv and install dependencies
+    command: |
+      python3 -m venv ~/venv
+      echo ". ~/venv/bin/activate" >> $BASH_ENV
+      source $BASH_ENV
+      make dependencies
+      pyenv local 3.6.2 3.5.3 3.4.4
 
-dependencies:
-  override:
-    - make dependencies
-    - pyenv local 3.6.2 3.5.3 3.4.4
+
+jobs:
+  lint:
+    docker:
+      - image: *docker_image
+    steps:
+      - checkout
+      - run:
+          <<: *dependencies
+      - run: make validate
+  test:
+    docker:
+      - image: *docker_image
+    environment:
+      TEST_REPORTS: /tmp/test-reports
+    steps:
+      - checkout
+      - run:
+          name: Install postgres
+          command: |
+            sudo apt-get update && sudo apt install postgresql postgresql-contrib
+      - run:
+          <<: *dependencies
+      - run: make test
+      - store_test_results:
+          path: /tmp/test-reports
+      - store_artifacts:
+          path: /tmp/test-reports
 
 test:
   override:
     - make validate
     - make test
-
-deployment:
-  production:
-    branch: master
-    owner: CloverHealth
-    commands:
-      - pip3 install -r deploy_requirements.txt
-      - python3 deploy.py prod
-

--- a/pytest_pgsql/plugin.py
+++ b/pytest_pgsql/plugin.py
@@ -21,6 +21,13 @@ def pytest_addoption(parser):
              '`pytest_pgsql` defaults to 32. Adjusting this up or down can '
              'help performance; see the Postgres documentation for more details.')
 
+    parser.addoption(
+        '--pg-conf-opt',
+        action='append',
+        help='Set postgres config options for the test database. '
+             'These are the options that are found in th postgres.conf file'
+             'Example: "--pg-conf-opt="track_commit_timestamp=True""')
+
 
 @pytest.fixture(scope='session')
 def database_uri(request):
@@ -40,6 +47,12 @@ def database_uri(request):
         work_mem_setting = '-c work_mem=%dMB ' % work_mem
 
     # pylint: disable=bad-continuation,deprecated-method
+    conf_opts = request.config.getoption('--pg-conf-opt')
+    if conf_opts:
+        conf_opts_string = ' -c ' + ' -c '.join(conf_opts)
+    else:
+        conf_opts_string = ''
+
     with testing.postgresql.Postgresql(
         postgres_args='-c TimeZone=UTC '
                       '-c fsync=off '
@@ -47,7 +60,9 @@ def database_uri(request):
                       '-c full_page_writes=off '
                       + work_mem_setting +
                       '-c checkpoint_timeout=30min '
-                      '-c bgwriter_delay=10000ms') as pgdb:
+                      '-c bgwriter_delay=10000ms'
+                      + conf_opts_string
+                        ) as pgdb:
         yield pgdb.url()
 
 

--- a/pytest_pgsql/plugin.py
+++ b/pytest_pgsql/plugin.py
@@ -25,7 +25,7 @@ def pytest_addoption(parser):
         '--pg-conf-opt',
         action='append',
         help='Set postgres config options for the test database. '
-             'These are the options that are found in th postgres.conf file'
+             'These are the options that are found in the postgres.conf file'
              'Example: "--pg-conf-opt="track_commit_timestamp=True""')
 
 

--- a/pytest_pgsql/tests/conftest.py
+++ b/pytest_pgsql/tests/conftest.py
@@ -4,8 +4,6 @@ import contextlib
 
 import pytest
 
-from pytest_pgsql import plugin
-
 
 @contextlib.contextmanager
 def check_teardown(fixture, execute):

--- a/pytest_pgsql/tests/conftest.py
+++ b/pytest_pgsql/tests/conftest.py
@@ -35,10 +35,10 @@ def clean_pgdb(postgresql_db):  # pragma: no cover
 
 
 @pytest.fixture(params=['non-transacted', 'transacted'])
-def clean_db(database_uri, request):
+def clean_db(database_uri, transacted_postgresql_db, postgresql_db, request):
     """Generic database - run a test with both the transacted and non-transacted
     databases."""
     if request.param == 'transacted':
-        yield from plugin.transacted_postgresql_db(database_uri, request)
+        yield transacted_postgresql_db
     else:
-        yield from plugin.postgresql_db(database_uri, request)
+        yield postgresql_db

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ passenv = *
 # verify that it installs extensions and ignores empty strings as expected. Make
 # sure you don't break it!
 commands =
-    coverage run -a -m pytest --pg-extensions=btree_gin,,btree_gist, {posargs} pytest_pgsql/tests
+    coverage run -a -m pytest --pg-conf-opt="track_commit_timestamp=True" --pg-extensions=btree_gin,,btree_gist, {posargs} pytest_pgsql/tests


### PR DESCRIPTION
Changes:

1. Adds a new flag `--pg-conf-opt` to update postgres configs. I needed this to enable the `track_commit_timestamp` config. Code was effectively copied from the suggestion in this old issue: https://github.com/CloverHealth/pytest-pgsql/issues/11

2. Small change to the `clean_db` fixture to avoid deprecated usage of direct fixtures (https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly)

**Note:**
Upgraded the Circle config.yaml to circle v2.0
Had to uncheck this setting in the repo settings:
https://circleci.com/docs/2.0/workflows/#workflows-waiting-for-status-in-github
