### PR TITLE
add missing an arg for the deploy script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
           <<: *dependencies
       - run: pip install -q -r deploy_requirements.txt
-      - run: python3 deploy.py
+      - run: python3 deploy.py prod
 
 workflows:
   version: 2


### PR DESCRIPTION
Last deploy job failed:
```
Traceback (most recent call last):
  File "deploy.py", line 129, in <module>
    raise RuntimeError('Require one argument indicating deploy target: `prod` or `test`.')
RuntimeError: Require one argument indicating deploy target: `prod` or `test`.
```
I missed an argument when converting the circle config to 2.0
Example:
https://github.com/CloverHealth/pytest-pgsql/blob/61d1c6df26be4bfcca25795b4eaaf2a352e4e0a9/circle.yml#L21

**Note:**
If the script fails I'll try to ssh into a circle container and run it from there. I'll open a new PR with the needed changes 🤞 