### PR TITLE
adding deploy key and removing twine register step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,6 +46,9 @@ jobs:
       - run:
           <<: *dependencies
       - run: pip install -q -r deploy_requirements.txt
+      - add_ssh_keys:
+          fingerprints:
+            - "f9:ef:5e:40:d5:ed:e3:86:a1:18:3e:09:85:93:ef:3a" # CAN I DO THIS?? prob not
       - run: python3 deploy.py prod
 
 workflows:

--- a/deploy.py
+++ b/deploy.py
@@ -28,15 +28,6 @@ def _pypi_push(dist):
             The distribution to push. Must be a valid directory; shell globs are
             NOT allowed.
     """
-    # Register all distributions and wheels with PyPI. We have to list the dist
-    # directory and register each file individually because `twine` doesn't
-    # handle globs.
-    for filename in os.listdir(dist):
-        full_path = os.path.join(dist, filename)
-        if os.path.isfile(full_path):
-            # This will fail if the project has never been uploaded, so use check=false
-            _shell('twine register ' + shlex.quote(full_path), check=False)
-
     _shell('twine upload ' + shlex.quote(dist + '/*'))
 
 


### PR DESCRIPTION
1. Adding the deploy key fingerprint so the deploy step can push/tag after the package is published to pypi
2. removing the register step as it is no longer necessary: https://twine.readthedocs.io/en/latest/#twine-register